### PR TITLE
Support TYPO3 11 and auto release into TER

### DIFF
--- a/.github/workflows/ter-release.yml
+++ b/.github/workflows/ter-release.yml
@@ -1,0 +1,28 @@
+name: TYPO3 Extension TER Release
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  ter-release:
+    name: TYPO3 TER Release
+    runs-on: ubuntu-latest
+    env:
+      TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
+      TYPO3_REPOSITORY_URL: ${{ secrets.TYPO3_REPOSITORY_URL }}
+      TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
+      TYPO3_API_USERNAME: ${{ secrets.TYPO3_API_USERNAME }}
+      TYPO3_API_PASSWORD: ${{ secrets.TYPO3_API_PASSWORD }}
+
+    steps:
+      - name: Grab new version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Configure PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+      - name: Install TYPO3 Tailor Extension
+        run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
+      - name: Release EXT:${{ env.TYPO3_EXTENSION_KEY }} as ${{ steps.get_version.outputs.VERSION }} to TER
+        run: php ~/.composer/vendor/bin/tailor ter:publish ${{ steps.get_version.outputs.VERSION }} --artefact=${{ env.TYPO3_REPOSITORY_URL }}/archive/${{ steps.get_version.outputs.VERSION }}.zip --comment="Successfully release new version ${{ steps.get_version.outputs.VERSION }} - see changelog at ${{ env.TYPO3_REPOSITORY_URL }}"

--- a/Classes/Services/AuthenticationService.php
+++ b/Classes/Services/AuthenticationService.php
@@ -1,8 +1,8 @@
 <?php
 namespace Mfc\BeuserIprange\Services;
 
+use TYPO3\CMS\Core\Authentication\AbstractAuthenticationService;
 use TYPO3\CMS\Core\Authentication\AbstractUserAuthentication;
-use TYPO3\CMS\Core\Service\AbstractService;
 
 /***************************************************************
  *  Copyright notice
@@ -37,30 +37,30 @@ use TYPO3\CMS\Core\Service\AbstractService;
  *      $GLOBALS['TYPO3_CONF_VARS']['BE']['userAuth']['ipRange'] = '192.168.0.1-192.168.0.15,96.0.112.80-96.0.112.96';
  *
  */
-class AuthenticationService extends AbstractService
+class AuthenticationService extends AbstractAuthenticationService
 {
     /**
-     * @param $subType
+     * @param string $mode
      * @param array $loginData
-     * @param array $authenticationInformation
-     * @param AbstractUserAuthentication $parentObject
+     * @param array $authInfo
+     * @param AbstractUserAuthentication $pObj
+     * @return void
      */
     public function initAuth(
-        $subType,
-        array $loginData,
-        array $authenticationInformation,
-        AbstractUserAuthentication &$parentObject
+        $mode,
+        $loginData,
+        $authInfo,
+        $pObj
     ) {
-
     }
 
     /**
      * authenticate a user
      *
-     * @param    array $user Data of user.
-     * @return    boolean
+     * @param array $user Data of user.
+     * @return boolean
      */
-    public function authUser($user)
+    public function authUser(array $user): bool
     {
         // if there's no IP-list given then the user is valid
         $result = 100;
@@ -102,7 +102,7 @@ class AuthenticationService extends AbstractService
      *
      * @return bool
      */
-    protected function inIPrange($ipStart, $ipEnd, $givenIP)
+    protected function inIPrange(string $ipStart, string $ipEnd, string $givenIP): bool
     {
         $start = ip2long($ipStart);
         $end = ip2long($ipEnd);

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,12 @@
   "name": "mfc/beuser-iprange",
   "description": "restrict BE-user to IP-range",
   "type": "typo3-cms-extension",
-  "version": "5.0.2",
+  "version": "6.0.2",
   "authors": [
+    {
+      "name": "Eike Drost",
+      "role": "Developer"
+    },
     {
       "name": "Simon Schmidt",
       "role": "Developer"
@@ -19,7 +23,7 @@
   },
   "require": {
     "php": "^7.2",
-    "typo3/cms-core": "^8.7||^9.5||^10.4"
+    "typo3/cms-core": "^8.7||^9.5||^10.4||^11.5"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -4,14 +4,14 @@ $EM_CONF['beuser_iprange'] = [
     'title' => 'IP-range for Admins/Be-user',
     'description' => 'restrict BE-user to IP-range',
     'category' => 'services',
-    'version' => '5.0.2',
+    'version' => '6.0.2',
     'state' => 'stable',
     'clearcacheonload' => 1,
-    'author' => 'Steffen Kamper, Simon Schmidt',
+    'author' => 'Steffen Kamper, Simon Schmidt, Eike Drost',
     'author_email' => 'typo3@marketing-factory.de',
     'constraints' => [
         'depends' => [
-            'typo3' => '8.7.0-10.4.99',
+            'typo3' => '8.7.0-11.5.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Includes support for typo3 11 and github workflow for auto release into TER

It is necessary to set following env's
`
TYPO3_EXTENSION_KEY: 

TYPO3_REPOSITORY_URL: 

TYPO3_API_TOKEN: 

TYPO3_API_USERNAME:      

TYPO3_API_PASSWORD:
`